### PR TITLE
fix for default profile not loading automatically

### DIFF
--- a/ksp2-inputbinder/Utils.cs
+++ b/ksp2-inputbinder/Utils.cs
@@ -8,7 +8,7 @@ namespace Codenade.Inputbinder
 {
     internal class Utils
     {
-        public static bool IsValidFileName(string name) => name.IndexOfAny(Path.GetInvalidFileNameChars().Concat(Path.GetInvalidPathChars()).ToArray()) >= 0;
+        public static bool IsValidFileName(string name) => name.IndexOfAny(Path.GetInvalidFileNameChars().Concat(Path.GetInvalidPathChars()).ToArray()) < 0;
 
         public static bool IsValidFileNameCharacter(char c) => !(Path.GetInvalidFileNameChars().Contains(c) || Path.GetInvalidPathChars().Contains(c));
 

--- a/ksp2-inputbinder/ksp2-inputbinder.csproj
+++ b/ksp2-inputbinder/ksp2-inputbinder.csproj
@@ -26,7 +26,7 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <DocumentationFile>
     </DocumentationFile>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
* fixed default profile not being loaded automatically
* debug build can now be debugged using [this](https://gist.github.com/gotmachine/d973adcb9ae413386291170fa346d043). It wasn't working before because apparently `<DebugType>` __must__ be set to `portable` instead of `full`