### PR TITLE
Improve throttle axis reset behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Dedicated actions to change the trim
 * Yaw Trim
 * Trim Reset
 
+### Throttle Axis Behavior
+
+- When the throttle level axis is moved, it is marked as _active_.
+- When the throttle delta buttons (default `Shift` and `Ctrl`) are pressed, the throttle level axis is marked as _inactive_.
+- While held, the throttle max and cutoff buttons (default `Z`/`X`) take priority over the throttle level axis.
+- When the throttle max and cutoff buttons are released, the throttle level is set back to the axis level if it is active.
+
 ## Configuration
 
 The mod settings can be accessed in-game in the flight view.

--- a/ksp2-inputbinder/GameInputUtils.cs
+++ b/ksp2-inputbinder/GameInputUtils.cs
@@ -117,6 +117,13 @@ namespace Codenade.Inputbinder
             return false;
         }
 
+        public static void OnStateChange(this InputAction action, Action<InputAction.CallbackContext> func)
+        {
+            action.started += func;
+            action.performed += func;
+            action.canceled += func;
+        }
+
         public static Dictionary<string, Type> GetInputSystemLayouts()
         {
             var im = typeof(InputSystem).GetField("s_Manager", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);

--- a/ksp2-inputbinder/Inputbinder.cs
+++ b/ksp2-inputbinder/Inputbinder.cs
@@ -148,8 +148,21 @@ namespace Codenade.Inputbinder
                 _button.State = visible;
         }
 
-        public void SetThrottle(float value)
+
+        /// <summary>
+        /// Sets the throttle level of the active vessel.
+        ///
+        /// By default, this does nothing if the throttle cutoff or max buttons are pressed.
+        /// Set `force` to `true` to override this behavior.
+        /// </summary>
+        /// <param name="value">The throttle level, clamped between 0 and 1.</param>
+        /// <param name="force">`true` proceeds setting the throttle level even when the throttle cutoff and max input buttons are pressed.</param>
+        public void SetThrottle(float value, bool force = false)
         {
+            // Prioritize throttle cutoff and max buttons over a throttle axis input.
+            var flight = GameManager.Instance.Game.Input.Flight;
+            if (!force && (flight.ThrottleCutoff.IsPressed() || flight.ThrottleMax.IsPressed()))
+                return;
             _vessel?.ApplyFlightCtrlState(new KSP.Sim.State.FlightCtrlStateIncremental() { mainThrottle = Mathf.Clamp01(value) });
         }
 

--- a/ksp2-inputbinder/Inputbinder.cs
+++ b/ksp2-inputbinder/Inputbinder.cs
@@ -16,16 +16,6 @@ using KSP.Sim;
 
 namespace Codenade.Inputbinder
 {
-    public static class OnStateChangeExtension
-    {
-        public static void OnStateChange(this InputAction action, Action<InputAction.CallbackContext> func)
-        {
-            action.started += func;
-            action.performed += func;
-            action.canceled += func;
-        }
-    }
-
     public sealed class Inputbinder : KerbalMonoBehaviour
     {
         public static event Action Initialized;
@@ -43,7 +33,6 @@ namespace Codenade.Inputbinder
         private BindingUI _bindingUI;
         private string _modRootPath;
         private bool _isInitialized;
-
         private bool _isThrottleAxisActive = false;
 
         public Inputbinder()
@@ -64,7 +53,6 @@ namespace Codenade.Inputbinder
             }
         }
 
-
         private void Initialize()
         {
             RemoveKSPsGamepadBindings();
@@ -77,7 +65,6 @@ namespace Codenade.Inputbinder
             GameManager.Instance.Game.Input.Flight.ThrottleMax.canceled += _ => ResetThrottle();
             GameManager.Instance.Game.Input.Flight.ThrottleCutoff.canceled += _ => ResetThrottle();
             _actionManager.Actions[Constants.ActionThrottleID].Action.OnStateChange(ctx => SetThrottleFromAxis(ctx.ReadValue<float>()));
-
             _actionManager.Actions[Constants.ActionTrimResetID].Action.performed += ctx => ResetTrim();
             _actionManager.Actions[Constants.ActionAPStabilityID].Action.performed += ctx => SetAPMode(AutopilotMode.StabilityAssist);
             _actionManager.Actions[Constants.ActionAPProgradeID].Action.performed += ctx => SetAPMode(AutopilotMode.Prograde);


### PR DESCRIPTION
This change builds off of #45 and includes its commit; I'm not aware of a better way to do chained pull requests.

New throttle behavior, documented in the README:

- When the throttle level axis is moved, it is marked as _active_.
- When the throttle delta buttons (default `Shift` and `Ctrl`) are pressed, the throttle level axis is marked as _inactive_.
- While held, the throttle max and cutoff buttons (default `Z`/`X`) take priority over the throttle level axis.
- When the throttle max and cutoff buttons are released, the throttle level is set back to the axis level if it is active.

Closes #43.